### PR TITLE
Inline INI documentation about custom attribute types

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
+++ b/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
@@ -62,6 +62,8 @@ RootSubtree=1
 # CustomAttributes[]=node_id
 # Name of the custom attribute shown in the editorial interface
 # CustomAttributeNames[node_id]=Node ID
+# text / checkbox / string (default)
+# CustomAttributeTypes[node_id]=string
 # UseBrowseMode[node_id]=true
 # ViewList[]=variation1
 # ViewName[variation1]=Main story 1


### PR DESCRIPTION
block/edit/edit.tpl supports the CustomAttributeTypes[] setting but it is not documented in block.ini
