### PR TITLE
Remove notice when cloning an eZPage object

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/classes/ezpage.php
+++ b/packages/ezflow_extension/ezextension/ezflow/classes/ezpage.php
@@ -303,9 +303,12 @@ class eZPage
      */
     public function __clone()
     {
-        foreach ( $this->attributes['zones'] as $i => $zone )
+        if ( isset( $this->attributes['zones'] ) )
         {
-            $this->attributes['zones'][$i] = clone $zone;
+            foreach ( $this->attributes['zones'] as $i => $zone )
+            {
+                $this->attributes['zones'][$i] = clone $zone;
+            }
         }
     }
 }


### PR DESCRIPTION
Remove a notice that happened when an eZPage attribute without zones where cloned.
