### PR TITLE
Allow custom attributes even on manual blocks

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/design/standard/templates/block/edit/edit.tpl
+++ b/packages/ezflow_extension/ezextension/ezflow/design/standard/templates/block/edit/edit.tpl
@@ -81,6 +81,7 @@
         {def $custom_attributes = ezini( $block.type, 'CustomAttributes', 'block.ini' )
              $custom_attribute_types = ezini( $block.type, 'CustomAttributeTypes', 'block.ini' )
              $custom_attribute_names = array()
+             $custom_attribute_selections = array()
              $loop_count=0}
         {if ezini_hasvariable( $block.type, 'CustomAttributeNames', 'block.ini' )}
             {set $custom_attribute_names = $custom_attribute_names|merge( ezini( $block.type, 'CustomAttributeNames', 'block.ini' ) )}
@@ -113,6 +114,14 @@
                         {/case}
                         {case match = 'string'}
                         <input id="block-custom_attribute-{$block_id}-{$loop_count}" class="textfield block-control" type="text" name="ContentObjectAttribute_ezpage_block_custom_attribute_{$attribute.id}[{$zone_id}][{$block_id}][{$custom_attrib}]" value="{$block.custom_attributes[$custom_attrib]}" />
+                        {/case}
+                        {case match = 'select'}
+                        {set $custom_attribute_selections = ezini( $block.type, concat( 'CustomAttributeSelection_', $custom_attrib ), 'block.ini' )}
+                        <select id="block-custom_attribute-{$block_id}-{$loop_count}" class="block-control" name="ContentObjectAttribute_ezpage_block_custom_attribute_{$attribute.id}[{$zone_id}][{$block_id}][{$custom_attrib}]">
+                            {foreach $custom_attribute_selections as $selection_value => $selection_name}
+                                <option value="{$selection_value|wash()}"{if eq( $block.custom_attributes[$custom_attrib], $selection_value )} selected="selected"{/if} />{$selection_name|wash()}</option>
+                            {/foreach}
+                        </select>
                         {/case}
                         {case}
                         <input id="block-custom_attribute-{$block_id}-{$loop_count}" class="textfield block-control" type="text" name="ContentObjectAttribute_ezpage_block_custom_attribute_{$attribute.id}[{$zone_id}][{$block_id}][{$custom_attrib}]" value="{$block.custom_attributes[$custom_attrib]}" />

--- a/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
+++ b/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
@@ -60,10 +60,16 @@ RootSubtree=1
 # FetchParameters[...]=string
 # FetchParameters[...]=integer
 # CustomAttributes[]=node_id
+# CustomAttributes[]=color
 # Name of the custom attribute shown in the editorial interface
 # CustomAttributeNames[node_id]=Node ID
-# text / checkbox / string (default)
+# CustomAttributeNames[color]=Color
+# text / checkbox / select / string (default)
 # CustomAttributeTypes[node_id]=string
+# CustomAttributeTypes[color]=select
+# CustomAttributeSelection_color[]
+# CustomAttributeSelection_color[blue]=Blue
+# CustomAttributeSelection_color[green]=Green
 # UseBrowseMode[node_id]=true
 # ViewList[]=variation1
 # ViewName[variation1]=Main story 1


### PR DESCRIPTION
There's no technical reason to disallow custom attributes on manual blocks.
