### PR TITLE
Additions to custom attributes: allow them even on manual blocks; support a "select" type

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/design/standard/templates/block/edit/edit.tpl
+++ b/packages/ezflow_extension/ezextension/ezflow/design/standard/templates/block/edit/edit.tpl
@@ -80,10 +80,12 @@
         <label>{$fetch_parameter}:</label> <input id="block-fetch-parameter-{$fetch_parameter}-{$block_id}" class="textfield block-control" type="text" name="ContentObjectAttribute_ezpage_block_fetch_param_{$attribute.id}[{$zone_id}][{$block_id}][{$fetch_parameter}]" value="{$fetch_params[$fetch_parameter]}" />
         {/if}
         {/foreach}
-    {elseif $is_custom}
+    {/if}
+    {if ezini_hasvariable( $block.type, 'CustomAttributes', 'block.ini' )}
         {def $custom_attributes = array()
              $custom_attribute_types = array()
              $custom_attribute_names = array()
+             $custom_attribute_selections = array()
              $loop_count = 0}
         {if ezini_hasvariable( $block.type, 'CustomAttributes', 'block.ini' )}
             {set $custom_attributes = ezini( $block.type, 'CustomAttributes', 'block.ini' )}
@@ -125,6 +127,14 @@
                         {case match = 'string'}
                         <input id="block-custom_attribute-{$block_id}-{$loop_count}" class="textfield block-control" type="text" name="ContentObjectAttribute_ezpage_block_custom_attribute_{$attribute.id}[{$zone_id}][{$block_id}][{$custom_attrib}]" value="{$block.custom_attributes[$custom_attrib]|wash()}" />
                         {/case}
+                        {case match = 'select'}
+                            {set $custom_attribute_selections = ezini( $block.type, concat( 'CustomAttributeSelection_', $custom_attrib ), 'block.ini' )}
+                            <select id="block-custom_attribute-{$block_id}-{$loop_count}" class="block-control" name="ContentObjectAttribute_ezpage_block_custom_attribute_{$attribute.id}[{$zone_id}][{$block_id}][{$custom_attrib}]">
+                                {foreach $custom_attribute_selections as $selection_value => $selection_name}
+                                    <option value="{$selection_value|wash()}"{if eq( $block.custom_attributes[$custom_attrib], $selection_value )} selected="selected"{/if} />{$selection_name|wash()}</option>
+                                {/foreach}
+                            </select>
+                        {/case}
                         {case}
                         <input id="block-custom_attribute-{$block_id}-{$loop_count}" class="textfield block-control" type="text" name="ContentObjectAttribute_ezpage_block_custom_attribute_{$attribute.id}[{$zone_id}][{$block_id}][{$custom_attrib}]" value="{$block.custom_attributes[$custom_attrib]|wash()}" />
                         {/case}
@@ -137,8 +147,11 @@
             {set $loop_count=inc( $loop_count )}
         {/foreach}
         {undef $loop_count}
-    {else}
-        <input id="block-add-item-{$block_id}" class="button block-control" name="CustomActionButton[{$attribute.id}_new_item_browse-{$zone_id}-{$block_id}]" type="submit" value="{'Add item'|i18n( 'design/standard/block/edit' )}" />
+    {/if}
+    {if and( not( $is_dynamic ), not( $is_custom ) )}
+        <div>
+            <input id="block-add-item-{$block_id}" class="button block-control" name="CustomActionButton[{$attribute.id}_new_item_browse-{$zone_id}-{$block_id}]" type="submit" value="{'Add item'|i18n( 'design/standard/block/edit' )}" />
+        </div>
     {/if}
     </div>
 </div>

--- a/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
+++ b/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
@@ -60,10 +60,16 @@ RootSubtree=1
 # FetchParameters[...]=string
 # FetchParameters[...]=integer
 # CustomAttributes[]=node_id
+# CustomAttributes[]=color
 # Name of the custom attribute shown in the editorial interface
 # CustomAttributeNames[node_id]=Node ID
-# text / checkbox / string (default)
+# CustomAttributeNames[color]=Color
+# text / checkbox / select / string (default)
 # CustomAttributeTypes[node_id]=string
+# CustomAttributeTypes[color]=select
+# CustomAttributeSelection_color[]
+# CustomAttributeSelection_color[blue]=Blue
+# CustomAttributeSelection_color[green]=Green
 # UseBrowseMode[node_id]=true
 # ViewList[]=variation1
 # ViewName[variation1]=Main story 1


### PR DESCRIPTION
This is a repeat of https://github.com/ezsystems/ezflow/pull/17 for a clean merge as requested by lserwatka
