### PR TITLE
Implements display latest userdraft-support for ezpage-datatype.

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/design/ezflow/override/templates/full/frontpage.tpl
+++ b/packages/ezflow_extension/ezextension/ezflow/design/ezflow/override/templates/full/frontpage.tpl
@@ -2,7 +2,7 @@
     <div class="class-frontpage">
 
     <div class="attribute-page">
-    {attribute_view_gui attribute=$node.object.data_map.page}
+    {attribute_view_gui attribute=$node.data_map.page}
     </div>
 
     </div>


### PR DESCRIPTION
Hi!

A while ago we got the following pull-request accepted: https://github.com/ezsystems/ezpublish/pull/298.

However we have some issues with the frontpage.tpl template. The problem arises because of the node.object.data_map reference. This function does not contain the feature submitted in the aforementioned pull-request. This commit is a quickfix and should not have any side-effects.

A better solution is to also fix the data_map function in ezcontentobject.php.
