### PR TITLE
Fix for eZ flow in eZ 4.7

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
+++ b/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
@@ -32,6 +32,7 @@ AllowedTypes[]=GMapItems
 [PushToBlock]
 # List of content classes using Layout datatype
 ContentClasses[]=frontpage
+ContentClasses[]=landing_page 
 # The subtree node ID from which to fetch objects with Layout datatype
 RootSubtree=1
 


### PR DESCRIPTION
Frontpage was renamed to Landing page, causing confusion when the user tries to use the feature push to block in admin interface 'cause the list is blank due to fact that there are no frontpage class in the default installation. Adding this line to block.ini will make push to block shows the existing landing pages, which are almost the same as frontpage.
