### PR TITLE
Push to block not working due to missing JS config variable

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/design/admin/templates/page/push.tpl
+++ b/packages/ezflow_extension/ezextension/ezflow/design/admin/templates/page/push.tpl
@@ -67,7 +67,8 @@
         eZPushToBlock.cfg = {ldelim}
             requesturl: "{'ezflow/get'|ezurl('no')}",
             nodename: "{$node.name|wash()|shorten( '50' )}",
-            imagepath: "{'ezpage/clock_ico.gif'|ezimage('no')}"
+            imagepath: "{'ezpage/clock_ico.gif'|ezimage('no')}",
+            nodeid: {$node.node_id}
         {rdelim}
         
         eZPushToBlock.init();


### PR DESCRIPTION
When trying to push a node to a block, the Block-Dropdown remains empty after having chosen a frontpage and a zone.

This is because in `modules/ezflow/get.php` the class identifier of the node to be pushed is checked against `AllowedClasses[]` coming from `block.ini`, but the needed `node_id` POST variable is not set.

This patch adds the missing configuration parameter.
