### PR TITLE
Fixed #019610: Problem replacing a node in a manual ezflow block with a ...

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/datatypes/ezpage/ezpagetype.php
+++ b/packages/ezflow_extension/ezextension/ezflow/datatypes/ezpage/ezpagetype.php
@@ -1009,7 +1009,7 @@ class eZPageType extends eZDataType
                                                 $updateQuery[] = " priority='" . $item->attribute( 'priority' ) . "' ";
                                             //if there is ts_hidden and ts_visible, update the two fields. This is the case when add items from history
                                             if ( $item->hasAttribute( 'ts_hidden' ) && $item->hasAttribute( 'ts_visible' ) )
-                                                $updateQuery[] = " ts_hidden='" . $item->attribute( 'ts_hidden' )
+                                                $updateQuery[] = " ts_hidden='" . $item->attribute( 'ts_hidden' ) . "' "
                                                              . ", ts_visible='" . $item->attribute( 'ts_visible' ) . "' ";
 
                                             if ( count( $updateQuery ) > 0)


### PR DESCRIPTION
...different location of the same object.

When a manual block item is removed and re-added before publishing, with the same object_id, it will be marked for update on publish. 

However, the node_id is assumed to be the same, which may not be the case.
