### PR TITLE
Fixed EZP-19668: eZ Flow layout zone changes are not visible in admin interface for already existing layouts

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/classes/ezpage.php
+++ b/packages/ezflow_extension/ezextension/ezflow/classes/ezpage.php
@@ -119,6 +119,23 @@ class eZPage
             }
         }
 
+        $zoneINI = eZINI::instance( 'zone.ini' );
+        $zla = $newObj->attribute( 'zone_layout' );
+        $zones = $zoneINI->variable( $newObj->attribute( 'zone_layout' ), 'Zones' );
+        foreach ( $zones as $zoneIdentifier )
+        {
+            $alreadyIncluded = false;
+            foreach ( $newObj->attribute( 'zones' ) as $inObjectZone )
+                $alreadyIncluded = $alreadyIncluded || ( $inObjectZone->attribute( 'zone_identifier' ) === $zoneIdentifier );
+            if ( !$alreadyIncluded )
+            {
+                $newZone = $newObj->addZone( new eZPageZone() );
+                $newZone->setAttribute( 'id', md5( mt_rand() . microtime() . $newObj->getZoneCount() ) );
+                $newZone->setAttribute( 'zone_identifier', $zoneIdentifier );
+                $newZone->setAttribute( 'action', 'add' );
+            }
+        }
+
         return $newObj;
     }
 


### PR DESCRIPTION
There are a couple of scenarios that may arise here.
- New zones are added to an existing layout. Editing content with said layout won't show the new zones
- Zones are deleted from an existing layout. "Empty" zone tabs will be showed when editing content with that layout
- Zone order is changed in the ini file. Block location will swap, upon editing, given that the zone-block mapping is established by zone order alone

An additional enhancement to the layout content edition I wish to add here is to allow re-mapping of zones every time a user wishes to do so. Currently this remapping is only allowed (forced) when one attempts to swap to a layout with less zones then the current one has. In my opinion, it would be useful to allow users to map left to top and right to bottom (for instance) when swapping from a side by side to a top / bottom layout. 

The first commit will only address the first scenario, given that that is the one that I suspect will happen more often (and it was the easiest to implement, to be honest)

If no one strongly objects, I'll proceed with the others shortly. 
