### PR TITLE
Support a custom start node for browse mode

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/datatypes/ezpage/ezpagetype.php
+++ b/packages/ezflow_extension/ezextension/ezflow/datatypes/ezpage/ezpagetype.php
@@ -724,9 +724,9 @@ class eZPageType extends eZDataType
                                            'cancel_page' => $redirectionURI,
                                            'persistent_data' => array( 'HasObjectInput' => 0 ) );
 
-                if( $blockINI->hasVariable( $block->attribute( 'type' ), 'ManualItemsStartNode' ) )
+                if( $blockINI->hasVariable( $block->attribute( 'type' ), 'ManualBlockStartBrowseNode' ) )
                 {
-                    $browseParameters['start_node'] = $blockINI->variable( $block->attribute( 'type' ), 'ManualItemsStartNode' );
+                    $browseParameters['start_node'] = $blockINI->variable( $block->attribute( 'type' ), 'ManualBlockStartBrowseNode' );
                 }
 
                 eZContentBrowse::browse( $browseParameters, $module );
@@ -784,9 +784,9 @@ class eZPageType extends eZDataType
                                            'cancel_page' => $redirectionURI,
                                            'persistent_data' => array( 'HasObjectInput' => 0 ) );
 
-                if( $blockINI->hasVariable( $block->attribute( 'type' ), 'FetchSourceStartNode' ) )
+                if( $blockINI->hasVariable( $block->attribute( 'type' ), 'DynamicBlockStartBrowseNode' ) )
                 {
-                    $browseParameters['start_node'] = $blockINI->variable( $block->attribute( 'type' ), 'FetchSourceStartNode' );
+                    $browseParameters['start_node'] = $blockINI->variable( $block->attribute( 'type' ), 'DynamicBlockStartBrowseNode' );
                 }
 
                 eZContentBrowse::browse( $browseParameters, $module );
@@ -826,13 +826,13 @@ class eZPageType extends eZDataType
                                            'cancel_page' => $redirectionURI,
                                            'persistent_data' => array( 'HasObjectInput' => 0 ) );
 
-                if( $blockINI->hasVariable( $block->attribute( 'type' ), 'CustomAttributeStartNode' ) )
+                if( $blockINI->hasVariable( $block->attribute( 'type' ), 'CustomAttributeStartBrowseNode' ) )
                 {
-                    $customAttributeStartNode = $blockINI->variable( $block->attribute( 'type' ), 'CustomAttributeStartNode' );
+                    $customAttributeStartBrowseNode = $blockINI->variable( $block->attribute( 'type' ), 'CustomAttributeStartBrowseNode' );
                     $customAttributeIdentifier = $params[3];
-                    if( isset( $customAttributeStartNode[$customAttributeIdentifier] ) )
+                    if( isset( $customAttributeStartBrowseNode[$customAttributeIdentifier] ) )
                     {
-                        $browseParameters['start_node'] = $customAttributeStartNode[$customAttributeIdentifier];
+                        $browseParameters['start_node'] = $customAttributeStartBrowseNode[$customAttributeIdentifier];
                     }
                 }
 

--- a/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
+++ b/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
@@ -45,7 +45,7 @@ RootSubtree=1
 # NumberOfArchivedItems=5
 # ManualAddingOfItems=disabled
 # Optional: set the browse mode start node when manual adding of items is enabled
-# ManualItemsStartNode=<node_id>
+# ManualBlockStartBrowseNode=<node_id>
 # TTL=86400
 # FetchClass=ezmExample
 # FetchFixedParameters[]
@@ -62,7 +62,7 @@ RootSubtree=1
 # FetchParameters[...]=string
 # FetchParameters[...]=integer
 # Optional: set the browse mode start node if using a source
-# FetchSourceStartNode=<node_id>
+# DynamicBlockStartBrowseNode=<node_id>
 # CustomAttributes[]=node_id
 # CustomAttributes[]=color
 # Name of the custom attribute shown in the editorial interface
@@ -76,7 +76,7 @@ RootSubtree=1
 # CustomAttributeSelection_color[green]=Green
 # UseBrowseMode[node_id]=true
 # Optional: set the browse mode start node for a custom attribute
-# CustomAttributeStartNode[node_id]=<node_id>
+# CustomAttributeStartBrowseNode[node_id]=<node_id>
 # ViewList[]=variation1
 # ViewName[variation1]=Main story 1
 #


### PR DESCRIPTION
Use a custom start node ID in each case where eZ Flow blocks use browse mode:
- Custom attribute
- Manual adding of items
- Fetch source

This is the same as pull request #23 but with CS fixes requested by @lolautruche and from a clean branch
