### PR TITLE
EZP-20654 - Remove extraneous block state data from eZPageBlockState cookie

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/design/standard/javascript/blocktools.js
+++ b/packages/ezflow_extension/ezextension/ezflow/design/standard/javascript/blocktools.js
@@ -252,7 +252,7 @@ YAHOO.ez.BlockCollapse = function(){
             Dom.replaceClass( collapsedEl, "collapsed", "expanded" );
         }
         
-        Cookie.removeSub("eZPageBlockHideState", getBlockID(o), {path: "/"});
+        Cookie.removeSub("eZPageBlockState", getBlockID(o), {path: "/"});
     };
     
     var collapseBlock = function(o) {
@@ -264,16 +264,16 @@ YAHOO.ez.BlockCollapse = function(){
             Dom.replaceClass( expandedEl, "expanded", "collapsed" );
         }
         
-        Cookie.setSub("eZPageBlockHideState", getBlockID(o), "1", {path: "/"});
+        Cookie.setSub("eZPageBlockState", getBlockID(o), "0", {path: "/"});
     }
     
     var updateBlockView = function(o) {
         var id = getBlockID(o);
 
         // Verify if the block should be collapsed by default:
-        var state = Cookie.getSub("eZPageBlockHideState", id);
+        var state = Cookie.getSub("eZPageBlockState", id);
 
-        if(state == "1") {
+        if(state == "0") {
             collapseBlock(o);
         } else {
             expandBlock(o);


### PR DESCRIPTION
Currently ezflow handles block visibility state (expanded / collapsed) by keeping track of individual blocks (by id) in an `eZPageBlockState` cookie, in a format like the following:

``` js
eZPageBlockState=id_a23db493243429c8087e087o987=1&
id_478d8a43429c8087e087o987=0....
```

According to HTTP RFC 6265, and implemented by most user agents (that I'm aware of), cookies are limited to 4096 bytes of content. In the (understandably unrealistic) situation where a user has an object with ~100/200 blocks, or the (very realistic) situation where the user has multiple objects with a number of blocks within, **this total size is very easily exhausted**.

This pull-request does not attempt to fully resolve the issue, as the implications could possibly be too wide-reaching, but reduces the amount of data put into a cookie to at least increase the ceiling for this limitation.
## Changes overview:
- Do **not** add the block's state to the cookie if it is expanded
- Do add the block's state to the cookie if it is collapsed (value `0` - the block is hidden)

This in reality translates the limit from a limitation of total number of blocks edited, to total number of blocks collapsed.

This change is expected to be backwards-compatible with existing cookie data.
