### PR TITLE
Fix #20839: Make sure the YUI3_config is used when loading YUI3 components

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/design/iphone/templates/pagelayout.tpl
+++ b/packages/ezflow_extension/ezextension/ezflow/design/iphone/templates/pagelayout.tpl
@@ -62,7 +62,7 @@
                 {ezscript_require( 'ezjsc::yui3' )}
                 <script type="text/javascript">
                 {literal}
-                    YUI().use('node','dom','event','anim', function(Y)  {
+                    YUI(YUI3_config).use('node','dom','event','anim', function(Y)  {
                         Y.one('#nav-menu-handler').on('click', function(e) {
                             var node = Y.one('#nav-menu-items');
                             node.setStyle( 'display', 'block' );


### PR DESCRIPTION
YUI().use is being called in pagelayout.tpl / iphone design. This causes some YUI modules to be fetched from external sources. 
