### PR TITLE
Fix #20451: block_view_gui for a manual fetched block don't use override templates

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/classes/ezpageblock.php
+++ b/packages/ezflow_extension/ezextension/ezflow/classes/ezpageblock.php
@@ -373,6 +373,9 @@ class eZPageBlock
         if ( $asObject )
         {
             $block = new eZPageBlock( null, $row[0] );
+            $block->attributes['type'] = $block->attributes['block_type'];
+            $viewList = eZINI::instance("block.ini")->variable( $block->attributes['type'], 'ViewList' );
+            $block->attributes['view'] = $viewList[0];
             return $block;
         }
         else


### PR DESCRIPTION
eZPageBlock->fetch calls **new eZPageBlock** which returns an eZPageBlock with several attributes, none of which are the **type** and **view** expected (I supposed, based on the debug output) by the rendering template.

With this patch:

**type** value is found in **block_type** therefore the assignation is linear.

I could not find **view** anywhere, but I could not find it either a way to select it while creating the block in the admin interface. It seems to always refer to the first available in block.ini ViewList array. Therefore, I am just setting the attribute **view** to the first value from **ViewList**.

It all seems to render properly now, if I manually fetch a block with
  {def $myblock=fetch('ezflow', 'block', hash( 'block_id', <myBlockId>))}
  {block_view_gui block=$myblock}
  {undef $myblock}
