### PR TITLE
Fix EZP-21878: layout attribute lost when importing class package

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/datatypes/ezpage/ezpagetype.php
+++ b/packages/ezflow_extension/ezextension/ezflow/datatypes/ezpage/ezpagetype.php
@@ -53,6 +53,37 @@ class eZPageType extends eZDataType
     }
 
     /**
+     * Serialize contentclass attribute
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @param DOMNode $attributeNode
+     * @param DOMNode $attributeParametersNode
+     */
+    function serializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
+    {
+        $defaultZoneLayout = $classAttribute->attribute( self::DEFAULT_ZONE_LAYOUT_FIELD );
+        $dom = $attributeParametersNode->ownerDocument;
+
+        $defaultLayoutNode = $dom->createElement( 'default-layout' );
+        $defaultLayoutNode->appendChild( $dom->createTextNode( $defaultZoneLayout ) );
+        $attributeParametersNode->appendChild( $defaultLayoutNode );
+    }
+
+    /**
+     * Unserialize contentclass attribute
+     *
+     * @param eZContentClassAttribute $classAttribute
+     * @param DOMNode $attributeNode
+     * @param DOMNode $attributeParametersNode
+     */
+    function unserializeContentClassAttribute( $classAttribute, $attributeNode, $attributeParametersNode )
+    {
+        $defaultZoneLayout = $attributeParametersNode->getElementsByTagName( 'default-layout' )->item( 0 )->textContent;
+        if ( $defaultZoneLayout !== false )
+            $classAttribute->setAttribute( self::DEFAULT_ZONE_LAYOUT_FIELD, $defaultZoneLayout );
+    }
+
+    /**
      * Initialize contentobject attribute content
      *
      * @param eZContentObjectAttribute $contentObjectAttribute


### PR DESCRIPTION
JiRA: https://jira.ez.no/browse/EZP-21878

eZFflow's ezpage datatype does not provide  a `serializeContentClassAttribute()` method, which causes it to be marked as 'unsupported' when exported in a class via the package system.

This PR implements the necessary methods for the attribute to be imported/exported.
