### PR TITLE
Fix EZP-22113: Adding items to block is not published immediately

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/classes/ezflowoperations.php
+++ b/packages/ezflow_extension/ezextension/ezflow/classes/ezflowoperations.php
@@ -182,7 +182,10 @@ class eZFlowOperations
 
         foreach ( $nodeArray as $nodeID )
         {
-            $time = time() - 5; // a safety margin
+            // a safety margin
+            $delay = intval( eZINI::instance( 'ezflow.ini' )->variable( 'SafetyDelay', 'DelayInSeconds' ) );
+
+            $time = time() - $delay;
 
             $nodeChanged = false;
 

--- a/packages/ezflow_extension/ezextension/ezflow/settings/ezflow.ini
+++ b/packages/ezflow_extension/ezextension/ezflow/settings/ezflow.ini
@@ -5,3 +5,9 @@
 
 [eZFlowOperations]
 UpdateOnPublish=enabled
+
+[SafetyDelay]
+# Age, in seconds, a block must be to be published when the object is sent for publishing.
+# You can lower the value if you are using a powerfull server and your editors experience side effect
+# from this delay (object has been published without the latest block updates).
+DelayInSeconds=5


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22113
## Description

If a user updates a block and quickly (less than 5 sec) sends the object for publishing, the block won't be taking into account. The object will have to be republished (manually or by the cronjob) to display the block.
## Proposed fix

The safety time can be configured. It can be used on very fast machines and should not introduce regression for users not experiencing this issue.
## Tests

Manual tests
