### PR TITLE
Fix EZP-22118: Valid nodes must take translation into account.

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/classes/ezflowpool.php
+++ b/packages/ezflow_extension/ezextension/ezflow/classes/ezflowpool.php
@@ -88,12 +88,14 @@ class eZFlowPool
         }
 
         $db = eZDB::instance();
-        $validNodes = $db->arrayQuery( "SELECT *
-                                        FROM ezm_pool, ezcontentobject_tree
+        $validNodes = $db->arrayQuery( "SELECT ezm_pool.node_id
+                                        FROM ezm_pool, ezcontentobject_tree, ezcontentobject
                                         WHERE ezm_pool.block_id='$blockID'
                                           AND ezm_pool.ts_visible>0
                                           AND ezm_pool.ts_hidden=0
                                           AND ezcontentobject_tree.node_id = ezm_pool.node_id
+                                          AND ezcontentobject.id = ezm_pool.object_id
+                                          AND " . eZContentLanguage::languagesSQLFilter( 'ezcontentobject' ) . "
                                           $visibilitySQL
                                         ORDER BY ezm_pool.priority DESC" );
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22118
## Description

Displayed nodes were not taking translations into account. 

That would cause null object to be loaded (with `$asObject = true`) which ended up displaying empty lines. If used with `$asObject = false` it would return a list of nodes that had object with no translation in this language.

This fixes the problem and also replaces:

``` sql
 SELECT * 
```

 by 

``` sql
 SELECT ezm_pool.node_id
```

Since we added another join and only node_id is used anyways.
## Tests

Manuel tests
