### PR TITLE
Fix EZP-24250: Not possible to remove ezflow blocks

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/design/standard/javascript/blocktools.js
+++ b/packages/ezflow_extension/ezextension/ezflow/design/standard/javascript/blocktools.js
@@ -525,7 +525,7 @@ var BlockDDInit = function() {
         });
 
         // configuring the up and down button
-        Y.all('#zone-' + BlockDDInit.cfg.zone + '-blocks input[name*="move_block"]').on('click', function (e) {
+        Y.all('#zone-' + BlockDDInit.cfg.zone + '-blocks input[name*="_move_block"]').on('click', function (e) {
             var blocks = Y.all('#zone-' + BlockDDInit.cfg.zone + '-blocks .block-container'),
                 movedBlock = e.target.ancestor('.block-container'),
                 goingUp = (e.target.get('name').indexOf('move_block_up') !== -1);


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24350

#### Problem ####
It is not possible to remove ezflow blocks (using the "trash" icon/button), since #67
The up/down and block ordering logic prevents default form submission, however the YUI selector was also being applied to the remove button (because `remove_block` name text contains `move_block`).

#### Fix ####
Modify the input selector to `_move_block` so it applies only to the move buttons.

#### Tests ####
Manual
