### PR TITLE
EZP-25771 - Add constructor to EzFlowFetchInterface

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/classes/ezflowfetchinterface.php
+++ b/packages/ezflow_extension/ezextension/ezflow/classes/ezflowfetchinterface.php
@@ -27,6 +27,13 @@
 interface eZFlowFetchInterface
 {
     /**
+     * Constructor
+     *
+     * @param array $parameters
+     */
+
+    public function __construct( $parameters );
+    /**
      * Fetches and returns content
      *
      * @param array $parameters

--- a/packages/ezflow_extension/ezextension/ezflow/classes/fetches/ezflowkeywordsfetch.php
+++ b/packages/ezflow_extension/ezextension/ezflow/classes/fetches/ezflowkeywordsfetch.php
@@ -26,6 +26,11 @@
 
 class eZFlowKeywordsFetch implements eZFlowFetchInterface
 {
+    public function __construct( $paramenters )
+    {
+        // nothing to be done
+    }
+
     public function fetch( $parameters, $publishedAfter, $publishedBeforeOrAt )
     {
         $ini = eZINI::instance( 'block.ini' );

--- a/packages/ezflow_extension/ezextension/ezflow/classes/fetches/ezflowlatestcontent.php
+++ b/packages/ezflow_extension/ezextension/ezflow/classes/fetches/ezflowlatestcontent.php
@@ -26,6 +26,11 @@
 
 class eZFlowLatestContent implements eZFlowFetchInterface
 {
+    public function __construct( $paramenters )
+    {
+        // nothing to be done
+    }
+
     public function fetch( $parameters, $publishedAfter, $publishedBeforeOrAt )
     {
         if ( isset( $parameters['Source'] ) )

--- a/packages/ezflow_extension/ezextension/ezflow/classes/fetches/ezflowlatestobjects.php
+++ b/packages/ezflow_extension/ezextension/ezflow/classes/fetches/ezflowlatestobjects.php
@@ -26,6 +26,11 @@
 
 class eZFlowLatestObjects implements eZFlowFetchInterface
 {
+    public function __construct( $paramenters )
+    {
+        // nothing to be done
+    }
+
     public function fetch( $parameters, $publishedAfter, $publishedBeforeOrAt )
     {
         if ( isset( $parameters['Source'] ) )

--- a/packages/ezflow_extension/ezextension/ezflow/classes/fetches/ezflowmcfetch.php
+++ b/packages/ezflow_extension/ezextension/ezflow/classes/fetches/ezflowmcfetch.php
@@ -2,6 +2,11 @@
 
 class eZFlowMCFetch implements eZFlowFetchInterface
 {
+    public function __construct( $paramenters )
+    {
+        // nothing to be done
+    }
+
     public function fetch( $parameters, $publishedAfter, $publishedBeforeOrAt )
     {
         if ( isset( $parameters['Source'] ) )


### PR DESCRIPTION
The fix for EZP-25771 causes a BC break because ezExtension is trying to instatiate using Reflector method newInstanceArgs() which causes an error is the class does not have a constructor.

This way we force all the FetchHandlers to implement a constructor.