### PR TITLE
EZP-26182: Support class limitation in block custom attributes

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/datatypes/ezpage/ezpagetype.php
+++ b/packages/ezflow_extension/ezextension/ezflow/datatypes/ezpage/ezpagetype.php
@@ -890,6 +890,7 @@ class eZPageType extends eZDataType
                 $page = $contentObjectAttribute->content();
                 $zone = $page->getZone( $params[1] );
                 $block = $zone->getBlock( $params[2] );
+                $customAttributeIdentifier = $params[3];
                 $blockINI = eZINI::instance( 'block.ini' );
 
                 $browseParameters = array( 'action_name' => 'CustomAttributeBrowse',
@@ -902,11 +903,14 @@ class eZPageType extends eZDataType
                 if( $blockINI->hasVariable( $block->attribute( 'type' ), 'CustomAttributeStartBrowseNode' ) )
                 {
                     $customAttributeStartBrowseNode = $blockINI->variable( $block->attribute( 'type' ), 'CustomAttributeStartBrowseNode' );
-                    $customAttributeIdentifier = $params[3];
                     if( isset( $customAttributeStartBrowseNode[$customAttributeIdentifier] ) )
                     {
                         $browseParameters['start_node'] = $customAttributeStartBrowseNode[$customAttributeIdentifier];
                     }
+                }
+                if( $blockINI->hasVariable( $block->attribute( 'type' ), 'CustomAttributeAllowedClasses_' . $customAttributeIdentifier ) )
+                {
+                    $browseParameters['class_array'] = $blockINI->variable( $block->attribute( 'type' ), 'CustomAttributeAllowedClasses_' . $customAttributeIdentifier );
                 }
 
                 eZContentBrowse::browse( $browseParameters, $module );

--- a/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
+++ b/packages/ezflow_extension/ezextension/ezflow/settings/block.ini
@@ -78,6 +78,8 @@ RootSubtree=1
 # UseBrowseMode[node_id]=true
 # Optional: set the browse mode start node for a custom attribute
 # CustomAttributeStartBrowseNode[node_id]=<node_id>
+# Optional: limit the browse mode selection to specific classes
+# CustomAttributeAllowedClasses_node_id[]=image
 # ViewList[]=variation1
 # ViewName[variation1]=Main story 1
 #


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-26182

If you have a custom attribute called "node_id" that is a "source" custom attribute, you can now limit the classes that can be selected in browse mode:

```
CustomAttributeAllowedClasses_<custom_attribute_identifier>[]=<class_identifier_1>
CustomAttributeAllowedClasses_<custom_attribute_identifier>[]=<class_identifier_2>
```

For example:

```
CustomAttributeAllowedClasses_node_id[]=image
CustomAttributeAllowedClasses_node_id[]=video
```
