### PR TITLE
Fix EZP-26275: Fatal error on invalid ezflow zone/version

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/modules/ezflow/zone.php
+++ b/packages/ezflow_extension/ezextension/ezflow/modules/ezflow/zone.php
@@ -31,7 +31,9 @@ $zoneID = $Params['ZoneID'];
 
 $contentObjectAttribute = eZContentObjectAttribute::fetch( $contentObjectAttributeID, $version );
 if ( !$contentObjectAttribute )
+{
     return $module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
+}
 
 $page = $contentObjectAttribute->content();
 $zone = $page->getZone( $zoneID );

--- a/packages/ezflow_extension/ezextension/ezflow/modules/ezflow/zone.php
+++ b/packages/ezflow_extension/ezextension/ezflow/modules/ezflow/zone.php
@@ -30,6 +30,9 @@ $version = $Params['Version'];
 $zoneID = $Params['ZoneID'];
 
 $contentObjectAttribute = eZContentObjectAttribute::fetch( $contentObjectAttributeID, $version );
+if ( !$contentObjectAttribute )
+    return $module->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
+
 $page = $contentObjectAttribute->content();
 $zone = $page->getZone( $zoneID );
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26275

If an unexisting ezflow ZoneId/version is requested, a fatal error will be thrown.
This adds a check for the attribute and returns a KERNEL_NOT_AVAILABLE / 404 instead.