### PR TITLE
Fix EZP-29600: eZ Flow pool table not updated on node swap

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/eventtypes/event/ezpageswap/ezpageswaptype.php
+++ b/packages/ezflow_extension/ezextension/ezflow/eventtypes/event/ezpageswap/ezpageswaptype.php
@@ -40,6 +40,8 @@ class eZPageSwapType extends eZWorkflowEventType
 
     function execute( $process, $event )
     {
+        $db = eZDB::instance();
+        $db->begin();
         $parameters = $process->attribute( 'parameter_list' );
         
         $oldNodeID = $parameters['node_id'];
@@ -62,7 +64,68 @@ class eZPageSwapType extends eZWorkflowEventType
             $newNodeBlock->setAttribute( 'node_id', $oldNodeID );
             $newNodeBlock->store();
         }
+
+        // Get the object IDs to update the pool items
+        $oldNode = eZContentObjectTreeNode::fetch( $oldNodeID );
+        $oldNodeObjectID = $oldNode->attribute( 'contentobject_id' );
+        $newNode = eZContentObjectTreeNode::fetch( $newNodeID ); 
+        $newNodeObjectID = $newNode->attribute( 'contentobject_id' );
         
+        // Update with the new object IDs
+        // Object IDs are keys, so we have to watch out for the case where the swapped nodes are part of the same block, in which case we need to swap the node IDs instead
+        $swappedBlockIDs = array();
+        $oldNodePoolItems = eZFlowPoolItem::fetchObjectList( eZFlowPoolItem::definition(), null, array( 'node_id' => $oldNodeID ) );
+        $newNodePoolItems = eZFlowPoolItem::fetchObjectList( eZFlowPoolItem::definition(), null, array( 'node_id' => $newNodeID ) );
+
+        // Loop over fetched pool items for old node
+        foreach( $oldNodePoolItems as $oldNodePoolItem )
+        {
+            // Check if the swapped node is part of the same block
+            $swappedNodePoolItem = eZFlowPoolItem::fetchObjectList( eZFlowPoolItem::definition(), null, array( 'node_id' => $newNodeID, 'block_id' => $oldNodePoolItem->attribute( 'block_id' ) ) );
+            if( empty( $swappedNodePoolItem ) )
+            {
+                $updateParameters = array(
+                                          'definition' => eZFlowPoolItem::definition(),
+                                          'update_fields' => array( 'object_id' => $oldNodeObjectID ),
+                                          'conditions' => array(
+                                                                'object_id' => $oldNodePoolItem->attribute( 'object_id' ),
+                                                                'block_id' => $oldNodePoolItem->attribute( 'block_id' )
+                                                               )
+                                         );
+                eZFlowPoolItem::updateObjectList( $updateParameters );
+            }
+            else
+            {
+                // Swap node IDs
+                $oldNodePoolItem->setAttribute( 'node_id', $newNodeID );
+                $oldNodePoolItem->store();
+                $swappedNodePoolItem[0]->setAttribute( 'node_id', $oldNodeID );
+                $swappedNodePoolItem[0]->store();
+                // Do not process this block ID again
+                $swappedBlockIDs[] = $oldNodePoolItem->attribute( 'block_id' );
+            }
+        }
+
+        // Loop over fetched pool items for new node
+        foreach( $newNodePoolItems as $newNodePoolItem )
+        {
+            // Don't process this block if both nodes IDs were already updated
+            if( in_array( $newNodePoolItem->attribute( 'block_id' ), $swappedBlockIDs ) )
+            {
+                continue;
+            }
+            $updateParameters = array(
+                                      'definition' => eZFlowPoolItem::definition(),
+                                      'update_fields' => array( 'object_id' => $newNodeObjectID ),
+                                      'conditions' => array(
+                                                            'object_id' => $newNodePoolItem->attribute( 'object_id' ),
+                                                            'block_id' => $newNodePoolItem->attribute( 'block_id' )
+                                                           )
+                                     );
+            eZFlowPoolItem::updateObjectList( $updateParameters );
+        }
+
+        $db->commit();
         return eZWorkflowType::STATUS_ACCEPTED;
     }
 }


### PR DESCRIPTION
The "eZ Page swap workflow event" updates blocks so that they are attached to new nodes. However, it does not update block items in the ezm_pool table.

If you have a block that contains Article A (node ID 8, object ID 8), then swap Article A with Article B (node ID 9, object ID 9), the ezm_pool entry will still have node_id = 8 and object_id = 8. Nothing will update the stored node ID and object ID values in the block except removing and re-adding the article. So the object ID is corrupt after a node swap. This results in Article A showing up in the back-end (because the back-end looks up the object ID) and Article B showing up in the front-end (because the front-end block template loops through $block.valid_nodes and thus looks up the node ID).

This PR updates the object IDs in ezm_pool since a node swap is technically an object swap. However, because ezm_pool uses object IDs as keys, if both nodes in the swap exist in a block, we swap the node IDs instead.