### PR TITLE
Allow browse start node id to be specified in the template

### DIFF
--- a/packages/ezflow_extension/ezextension/ezflow/datatypes/ezpage/ezpagetype.php
+++ b/packages/ezflow_extension/ezextension/ezflow/datatypes/ezpage/ezpagetype.php
@@ -781,12 +781,9 @@ class eZPageType extends eZDataType
                                                                             'value' => $contentObjectAttribute->attribute( 'id' ) ),
                                            'from_page' => $redirectionURI,
                                            'cancel_page' => $redirectionURI,
-                                           'persistent_data' => array( 'HasObjectInput' => 0 ) );
-
-                if( $blockINI->hasVariable( $block->attribute( 'type' ), 'ManualBlockStartBrowseNode' ) )
-                {
-                    $browseParameters['start_node'] = $blockINI->variable( $block->attribute( 'type' ), 'ManualBlockStartBrowseNode' );
-                }
+                                           'persistent_data' => array( 'HasObjectInput' => 0 ),
+                                           'start_node' => $this->getBrowseStartNodeId( $http, $blockINI, $contentObjectAttribute, $block, $params ),
+                );
 
                 eZContentBrowse::browse( $browseParameters, $module );
                 break;
@@ -1246,6 +1243,32 @@ class eZPageType extends eZDataType
         $rootNode = $attributeNode->childNodes->item( 0 );
         $xmlString = $rootNode ? $rootNode->ownerDocument->saveXML( $rootNode ) : '';
         $objectAttribute->setAttribute( 'data_text', $xmlString );
+    }
+
+    /**
+     * @param eZHTTPTool $http
+     * @param eZINI $blockIni
+     * @param eZContentObjectAttribute $contentObjectAttribute
+     * @param eZPageBlock $block
+     * @param array $params
+     * @return int|null
+     */
+    protected function getBrowseStartNodeId( $http, $blockIni, $contentObjectAttribute, $block, $params )
+    {
+        $return = null;
+
+        if( $http->hasVariable( 'start-browse-node-id' ) )
+        {
+            $startBrowseNodeIds = $http->variable( 'start-browse-node-id' );
+            $return = $startBrowseNodeIds[ $contentObjectAttribute->attribute( 'id' ) ][ $params[1] ][ $params[2] ];
+        }
+
+        if( !$return && $blockIni->hasVariable( $block->attribute( 'type' ), 'ManualBlockStartBrowseNode' ) )
+        {
+            $return = $blockIni->variable( $block->attribute( 'type' ), 'ManualBlockStartBrowseNode' );
+        }
+
+        return $return;
     }
 }
 

--- a/packages/ezflow_extension/ezextension/ezflow/design/standard/templates/block/edit/edit.tpl
+++ b/packages/ezflow_extension/ezextension/ezflow/design/standard/templates/block/edit/edit.tpl
@@ -157,6 +157,9 @@
     {/if}
     {if and( not( $is_dynamic ), not( $is_custom ) )}
         <div>
+            {if ezini( $block.type, 'ManualBlockStartBrowseNode', 'block.ini' )}
+                <input type="hidden" name="start-browse-node-id[{$attribute.id}][{$zone_id}][{$block_id}]" value="{ezini( $block.type, 'ManualBlockStartBrowseNode', 'block.ini' )}" />
+            {/if}
             <input id="block-add-item-{$block_id}" class="button block-control" name="CustomActionButton[{$attribute.id}_new_item_browse-{$zone_id}-{$block_id}]" type="submit" value="{'Add item'|i18n( 'design/standard/block/edit' )}" />
         </div>
     {/if}


### PR DESCRIPTION
This pull requests moves the logic for the browse start node ID (when browsing the content structure for a new content object for the block) into the template. That makes it easier to override that logic in client project. With that pull request it is not required to change the core PHP script if you want to change the start browsing node it.
